### PR TITLE
Moved caddy out of this project

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,3 +1,0 @@
-FROM caddy:2.6.4-alpine
-
-COPY Caddyfile /etc/caddy/Caddyfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,6 @@ version: '3.8'
 
 volumes:
     db:
-    caddy_data:
 
 services:
   db:
@@ -19,17 +18,18 @@ services:
     restart: unless-stopped
     build: ./frontend
     env_file: frontend/.env
-
-  caddy:
-    restart: unless-stopped
-    build: ./caddy
-    volumes:
-      - caddy_data:/data
-    ports:
-      - "80:80"
-      - "443:443"
+    networks:
+      - caddy-network
+      - default
 
   api:
     restart: unless-stopped
     build: ./backend
     env_file: .env.backend
+    networks:
+      - caddy-network
+      - default
+
+networks:
+  caddy-network:
+    external: true


### PR DESCRIPTION
Caddy flyttades ut ur detta projekt till `/opt/caddy` på ssm-server så man kan hosta fler saker på den burken än bara detta. Där ligger en Caddyfile som bland annat importerar `/opt/ssm-wargame/caddy/Caddyfile`. Just nu har jag lämnat den modifierade `docker-compose.yml` ocommitad på ssm-server (så det inte ligger en composefil som inte matchar nuvarande deployment), så innan git kan pulla nästa commit behöver den nog revertas.