### PR TITLE
Sortera "Tävling" inverterad alfabetiskt

### DIFF
--- a/frontend/pages/challenges.vue
+++ b/frontend/pages/challenges.vue
@@ -69,7 +69,7 @@ const router = useRouter()
 const { challFilter } = storeToRefs(useChallengeStore())
 
 await useAsyncData('challenges', challs.getChallenges)
-await useAsyncData('events', challs.getEvents.sort((a,b) => a.name < b.name))
+await useAsyncData('events', challs.getEvents)
 
 onMounted(() => {
     challs.getChallenges()

--- a/frontend/pages/challenges.vue
+++ b/frontend/pages/challenges.vue
@@ -69,7 +69,7 @@ const router = useRouter()
 const { challFilter } = storeToRefs(useChallengeStore())
 
 await useAsyncData('challenges', challs.getChallenges)
-await useAsyncData('events', challs.getEvents)
+await useAsyncData('events', challs.getEvents.sort((a,b) => a.name < b.name))
 
 onMounted(() => {
     challs.getChallenges()

--- a/frontend/store/challenges.ts
+++ b/frontend/store/challenges.ts
@@ -26,7 +26,7 @@ export const useChallengeStore = defineStore('challenges', {
         },
         async getEvents() {
             const cats = await http('/events')
-            this.events = cats
+            this.events = cats.sort((a, b) => a.name < b.name)
         },
         async getAuthors() {
             const authors = await http('/authors')


### PR DESCRIPTION
Tävlingarna har hittills visats lite huller om buller, men nu sorteras de innan de skickas iväg (tror jag, jag har inte kunnat testa). Inverterad alfabetisk gör att de senaste åren kommer först. Egentligen är det kanske bättre att de sorteras redan i [databasen](https://github.com/Kodsport/sakerhetssm-wargame-platform/blob/24c8f032b92356f08a77d379ca12e4841eca7a83/backend/internal/api/challenge/events.go#L13), men jag har inte tillgång dit